### PR TITLE
Add daily scheduler, new_today view, /api/apartments endpoints, user_filters DB table

### DIFF
--- a/Database/database.py
+++ b/Database/database.py
@@ -1,25 +1,23 @@
 import os
 import psycopg2
-from psycopg2.extras import execute_values
+from psycopg2.extras import execute_values, RealDictCursor
 from dotenv import load_dotenv
 
-# Încarcă variabilele din fișierul .env aflat în rădăcina proiectului
 dotenv_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '.env')
 load_dotenv(dotenv_path)
 
-# Preluare date din .env
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_NAME = os.getenv("DB_NAME", "apartments_vatty")
 DB_USER = os.getenv("DB_USER", "gabriel")
 DB_PASS = os.getenv("DB_PASS")
 DB_PORT = os.getenv("DB_PORT", "5432")
 
-# Construire URL conexiune
 if DB_PASS:
     DB_URL = f"postgresql://{DB_USER}:{DB_PASS}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
 else:
     print("WARNING: DB_PASS nu a fost găsit în .env. Se încearcă conexiune fără parolă.")
     DB_URL = f"postgresql://{DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+
 
 def get_connection():
     try:
@@ -28,40 +26,36 @@ def get_connection():
         print(f"Eroare critică la conectarea cu baza de date: {e}")
         raise e
 
+
 def init_db():
     conn = get_connection()
     cur = conn.cursor()
-    # Calea relativa catre init_db.sql
     sql_path = os.path.join(os.path.dirname(__file__), 'init_db.sql')
-    if os.path.exists(sql_path):
-        with open(sql_path, 'r') as f:
-            cur.execute(f.read())
-        conn.commit()
-        print("Database initialized (checked schema).")
-    else:
-        print("Warning: init_db.sql not found, skipping init.")
+    migrate_path = os.path.join(os.path.dirname(__file__), 'migrate_v2.sql')
+    for path in [sql_path, migrate_path]:
+        if os.path.exists(path):
+            with open(path, 'r') as f:
+                cur.execute(f.read())
+            conn.commit()
+    print("Database initialized (checked schema).")
     cur.close()
     conn.close()
 
+
 def insert_batch_apartments(apartments_list):
-    """
-    Insereaza date in scraped_apartments. 
-    Gestioneaza cheile lipsa prin .get() care returneaza None default.
-    """
     if not apartments_list:
         print("Lista de apartamente este goala. Nimic de inserat în DB.")
-        return
+        return 0
 
     conn = get_connection()
     cur = conn.cursor()
 
-    # Query-ul trebuie sa se potriveasca cu coloanele din DB
     query = """
-        INSERT INTO scraped_apartments 
+        INSERT INTO scraped_apartments
         (source_website, title, price, location, surface, rooms, description, link, floor, contact_name, phone_number)
         VALUES %s
-        ON CONFLICT (title, price, location, surface) 
-        DO UPDATE SET 
+        ON CONFLICT (title, price, location, surface)
+        DO UPDATE SET
             scraped_at = CURRENT_TIMESTAMP,
             link = EXCLUDED.link,
             description = EXCLUDED.description,
@@ -86,8 +80,10 @@ def insert_batch_apartments(apartments_list):
             app.get('phone_number')
         ))
 
+    inserted = 0
     try:
         execute_values(cur, query, values)
+        inserted = cur.rowcount
         conn.commit()
         print(f"DB Success: {len(values)} randuri procesate/inserate.")
     except Exception as e:
@@ -96,3 +92,192 @@ def insert_batch_apartments(apartments_list):
     finally:
         cur.close()
         conn.close()
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# user_filters
+# ---------------------------------------------------------------------------
+
+def get_active_filters():
+    """Returnează cel mai recent set de filtre salvat de utilizator."""
+    conn = get_connection()
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute("SELECT * FROM user_filters ORDER BY created_at DESC LIMIT 1")
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    return dict(row) if row else {"rooms": 2, "sector": 0, "price_min": 10000, "price_max": 150000}
+
+
+def save_filters(rooms, sector, price_min, price_max):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO user_filters (rooms, sector, price_min, price_max) VALUES (%s, %s, %s, %s) RETURNING id",
+        (rooms, sector, price_min, price_max)
+    )
+    new_id = cur.fetchone()[0]
+    conn.commit()
+    cur.close()
+    conn.close()
+    return new_id
+
+
+# ---------------------------------------------------------------------------
+# run_log
+# ---------------------------------------------------------------------------
+
+def log_run_start(site):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO run_log (site) VALUES (%s) RETURNING id",
+        (site,)
+    )
+    run_id = cur.fetchone()[0]
+    conn.commit()
+    cur.close()
+    conn.close()
+    return run_id
+
+
+def log_run_finish(run_id, apartments_found, new_count):
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE run_log SET finished_at = NOW(), apartments_found = %s, new_count = %s WHERE id = %s",
+        (apartments_found, new_count, run_id)
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# "nou azi" — VIEW-based diff
+# ---------------------------------------------------------------------------
+
+def ensure_new_today_view():
+    """
+    Creează/înlocuiește VIEW-ul new_today.
+    Apartamente al căror scraped_at e azi ȘI nu aveau scraped_at ieri
+    (adică sunt cu adevărat noi, nu simple re-scrape-uri).
+    Strategia: comparăm pe cheia unică (title, price, location, surface).
+    """
+    ddl = """
+    CREATE OR REPLACE VIEW new_today AS
+    SELECT a.*
+    FROM scraped_apartments a
+    WHERE DATE(a.scraped_at) = CURRENT_DATE
+      AND NOT EXISTS (
+          SELECT 1 FROM scraped_apartments b
+          WHERE b.title = a.title
+            AND b.price = a.price
+            AND b.location = a.location
+            AND b.surface = a.surface
+            AND DATE(b.scraped_at) < CURRENT_DATE
+      )
+    ORDER BY a.scraped_at DESC;
+    """
+    conn = get_connection()
+    cur = conn.cursor()
+    cur.execute(ddl)
+    conn.commit()
+    cur.close()
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Query-uri pentru endpoint-urile API
+# ---------------------------------------------------------------------------
+
+def query_apartments(rooms=None, sector=None, price_min=None, price_max=None,
+                     page=1, per_page=20, sort_by="scraped_at", sort_dir="desc"):
+    allowed_sort = {"scraped_at", "price", "surface", "rooms", "location"}
+    if sort_by not in allowed_sort:
+        sort_by = "scraped_at"
+    sort_dir = "DESC" if sort_dir.lower() == "desc" else "ASC"
+
+    conditions = []
+    params = []
+
+    if rooms is not None:
+        conditions.append("rooms = %s")
+        params.append(rooms)
+    if sector is not None and sector != 0:
+        conditions.append("location ILIKE %s")
+        params.append(f"%sector {sector}%")
+    if price_min is not None:
+        conditions.append("price >= %s")
+        params.append(price_min)
+    if price_max is not None:
+        conditions.append("price <= %s")
+        params.append(price_max)
+
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    offset = (page - 1) * per_page
+
+    conn = get_connection()
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+
+    cur.execute(f"SELECT COUNT(*) FROM scraped_apartments {where}", params)
+    total = cur.fetchone()["count"]
+
+    cur.execute(
+        f"""SELECT id, source_website, title, price, location, surface, rooms,
+                   floor, contact_name, phone_number, link, description, scraped_at
+            FROM scraped_apartments {where}
+            ORDER BY {sort_by} {sort_dir}
+            LIMIT %s OFFSET %s""",
+        params + [per_page, offset]
+    )
+    rows = [dict(r) for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+
+    # scraped_at → string ISO
+    for r in rows:
+        if r.get("scraped_at"):
+            r["scraped_at"] = r["scraped_at"].isoformat()
+
+    return {"total": total, "page": page, "per_page": per_page, "apartments": rows}
+
+
+def query_new_today(rooms=None, sector=None, price_min=None, price_max=None):
+    conditions = []
+    params = []
+
+    if rooms is not None:
+        conditions.append("rooms = %s")
+        params.append(rooms)
+    if sector is not None and sector != 0:
+        conditions.append("location ILIKE %s")
+        params.append(f"%sector {sector}%")
+    if price_min is not None:
+        conditions.append("price >= %s")
+        params.append(price_min)
+    if price_max is not None:
+        conditions.append("price <= %s")
+        params.append(price_max)
+
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    conn = get_connection()
+    cur = conn.cursor(cursor_factory=RealDictCursor)
+    cur.execute(
+        f"""SELECT id, source_website, title, price, location, surface, rooms,
+                   floor, contact_name, phone_number, link, description, scraped_at
+            FROM new_today {where}""",
+        params
+    )
+    rows = [dict(r) for r in cur.fetchall()]
+    cur.close()
+    conn.close()
+
+    for r in rows:
+        if r.get("scraped_at"):
+            r["scraped_at"] = r["scraped_at"].isoformat()
+
+    return {"count": len(rows), "apartments": rows}

--- a/Database/migrate_v2.sql
+++ b/Database/migrate_v2.sql
@@ -1,0 +1,30 @@
+-- Migration v2: user_filters, run_log, index on scraped_at
+
+-- Index pe scraped_at pentru query-uri rapide per zi
+CREATE INDEX IF NOT EXISTS idx_scraped_at ON scraped_apartments (scraped_at);
+
+-- Filtrele salvate de utilizator (folosite de scheduler la rularea automată)
+CREATE TABLE IF NOT EXISTS user_filters (
+    id SERIAL PRIMARY KEY,
+    rooms INTEGER,
+    sector INTEGER,
+    price_min INTEGER,
+    price_max INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Log per rulare zilnică
+CREATE TABLE IF NOT EXISTS run_log (
+    id SERIAL PRIMARY KEY,
+    run_date DATE NOT NULL DEFAULT CURRENT_DATE,
+    site VARCHAR(50) NOT NULL,
+    apartments_found INTEGER DEFAULT 0,
+    new_count INTEGER DEFAULT 0,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    finished_at TIMESTAMP
+);
+
+-- Inserează filtre default dacă tabelul e gol
+INSERT INTO user_filters (rooms, sector, price_min, price_max)
+SELECT 2, 0, 10000, 150000
+WHERE NOT EXISTS (SELECT 1 FROM user_filters LIMIT 1);

--- a/app.py
+++ b/app.py
@@ -1,14 +1,28 @@
 from flask import Flask, render_template
 from flask_cors import CORS
 from routes import routes
+from Database.database import init_db, ensure_new_today_view
+from scheduler import create_scheduler
 
 app = Flask(__name__)
-CORS(app)  # This allows requests from any origin
+CORS(app)
 app.register_blueprint(routes)
+
 
 @app.route("/")
 def index():
     return render_template("index.html")
 
+
 if __name__ == "__main__":
-    app.run(debug=True)
+    init_db()
+    ensure_new_today_view()
+
+    scheduler = create_scheduler()
+    scheduler.start()
+    print("[app] Scheduler pornit — scraping zilnic la 07:00 Europe/Bucharest")
+
+    try:
+        app.run(debug=False, use_reloader=False)
+    finally:
+        scheduler.shutdown()

--- a/routes.py
+++ b/routes.py
@@ -1,33 +1,36 @@
 from flask import Blueprint, jsonify, send_file, request
 from scrapers.runner import status, start_scraper
 from flask_cors import CORS
+from Database.database import (
+    get_active_filters, save_filters,
+    query_apartments, query_new_today,
+)
 import os
 
 routes = Blueprint("routes", __name__)
 CORS(routes)
+
+# ---------------------------------------------------------------------------
+# Scraper manual (existent)
+# ---------------------------------------------------------------------------
 
 @routes.route("/scrape/<site>")
 def scrape(site):
     if site not in status:
         return jsonify({"error": "Unknown site"}), 404
 
-    # Preluam parametrii din URL (trimisi de frontend)
     try:
         rooms = int(request.args.get('rooms', 2))
         price_min = int(request.args.get('price_min', 10000))
         price_max = int(request.args.get('price_max', 81000))
-        # Adaugam preluarea sectorului (default Sector 1)
         sector = int(request.args.get('sector', 1))
     except ValueError:
         return jsonify({"error": "Parametrii de filtrare invalizi"}), 400
 
-    # VALIDARE BACKEND: Verificam logica preturilor
     if price_min > price_max:
         return jsonify({"error": "Prețul minim nu poate fi mai mare decât prețul maxim."}), 400
 
     print(f"Request scrape {site}: Camere={rooms}, Sector={sector}, Pret={price_min}-{price_max}")
-
-    # Trimitem filtrele (inclusiv sectorul) catre runner
     started = start_scraper(site, rooms, price_min, price_max, sector)
     return jsonify({"started": started})
 
@@ -45,14 +48,86 @@ def download(site):
         return "Unknown site", 404
 
     file_path = status[site]["file"]
-
     if not file_path or not os.path.exists(file_path):
         return "Fisier indisponibil (posibil sters sau negenerat inca).", 404
 
-    # MODIFICARE: Nu mai stergem fisierul imediat dupa trimitere.
-    # Astfel, utilizatorul poate apasa "Descarca" de mai multe ori.
     try:
         return send_file(file_path, as_attachment=True)
     except Exception as e:
         print(f"Eroare la download: {e}")
         return "Eroare server la descarcare", 500
+
+
+# ---------------------------------------------------------------------------
+# Filtre utilizator
+# ---------------------------------------------------------------------------
+
+@routes.route("/api/filters", methods=["GET"])
+def get_filters():
+    return jsonify(get_active_filters())
+
+
+@routes.route("/api/filters", methods=["POST"])
+def post_filters():
+    data = request.get_json(force=True) or {}
+    try:
+        rooms = int(data.get("rooms", 2))
+        sector = int(data.get("sector", 0))
+        price_min = int(data.get("price_min", 10000))
+        price_max = int(data.get("price_max", 150000))
+    except (ValueError, TypeError):
+        return jsonify({"error": "Parametrii invalizi"}), 400
+
+    if price_min > price_max:
+        return jsonify({"error": "price_min > price_max"}), 400
+
+    new_id = save_filters(rooms, sector, price_min, price_max)
+    return jsonify({"saved": True, "id": new_id}), 201
+
+
+# ---------------------------------------------------------------------------
+# GET /api/apartments — toate, cu filtre opționale + paginare
+# ---------------------------------------------------------------------------
+
+@routes.route("/api/apartments")
+def api_apartments():
+    try:
+        rooms = int(request.args["rooms"]) if "rooms" in request.args else None
+        sector = int(request.args["sector"]) if "sector" in request.args else None
+        price_min = int(request.args["price_min"]) if "price_min" in request.args else None
+        price_max = int(request.args["price_max"]) if "price_max" in request.args else None
+        page = max(1, int(request.args.get("page", 1)))
+        per_page = min(100, max(1, int(request.args.get("per_page", 20))))
+        sort_by = request.args.get("sort_by", "scraped_at")
+        sort_dir = request.args.get("sort_dir", "desc")
+    except ValueError:
+        return jsonify({"error": "Parametrii invalizi"}), 400
+
+    result = query_apartments(
+        rooms=rooms, sector=sector,
+        price_min=price_min, price_max=price_max,
+        page=page, per_page=per_page,
+        sort_by=sort_by, sort_dir=sort_dir,
+    )
+    return jsonify(result)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/apartments/new — doar cele apărute azi față de ieri
+# ---------------------------------------------------------------------------
+
+@routes.route("/api/apartments/new")
+def api_apartments_new():
+    try:
+        rooms = int(request.args["rooms"]) if "rooms" in request.args else None
+        sector = int(request.args["sector"]) if "sector" in request.args else None
+        price_min = int(request.args["price_min"]) if "price_min" in request.args else None
+        price_max = int(request.args["price_max"]) if "price_max" in request.args else None
+    except ValueError:
+        return jsonify({"error": "Parametrii invalizi"}), 400
+
+    result = query_new_today(
+        rooms=rooms, sector=sector,
+        price_min=price_min, price_max=price_max,
+    )
+    return jsonify(result)

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,83 @@
+"""
+Scheduler zilnic: la 07:00 pornește toate scraperele cu filtrele salvate în DB.
+"""
+import threading
+import logging
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from Database.database import (
+    get_active_filters, log_run_start, log_run_finish,
+    ensure_new_today_view
+)
+from scrapers.imobiliare_scraper import scrape_imobiliare
+from scrapers.publi24_scraper import scrape_publi24
+from scrapers.romimo_scraper import scrape_romimo
+
+log = logging.getLogger(__name__)
+
+SCRAPERS = {
+    "imobiliare": scrape_imobiliare,
+    "publi24": scrape_publi24,
+    "romimo": scrape_romimo,
+}
+
+
+def _run_single(site, scraper_fn, filters):
+    rooms = filters["rooms"]
+    sector = filters["sector"]
+    price_min = filters["price_min"]
+    price_max = filters["price_max"]
+
+    run_id = log_run_start(site)
+    log.info(f"[scheduler] Start {site}: rooms={rooms}, sector={sector}, pret={price_min}-{price_max}")
+
+    try:
+        file_path = scraper_fn(rooms, price_min, price_max, sector)
+        # Reconstruim view-ul după fiecare scraper finalizat
+        ensure_new_today_view()
+
+        # Citim câte apartamente noi au apărut (din view)
+        from Database.database import get_connection
+        from psycopg2.extras import RealDictCursor
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM scraped_apartments WHERE DATE(scraped_at) = CURRENT_DATE")
+        found = cur.fetchone()[0]
+        cur.execute("SELECT COUNT(*) FROM new_today")
+        new_c = cur.fetchone()[0]
+        cur.close()
+        conn.close()
+
+        log_run_finish(run_id, found, new_c)
+        log.info(f"[scheduler] Finished {site}: found={found}, new={new_c}, file={file_path}")
+    except Exception as e:
+        log.error(f"[scheduler] Eroare {site}: {e}")
+        log_run_finish(run_id, 0, 0)
+
+
+def run_all_scrapers():
+    """Pornește toate scraperele în paralel cu filtrele active din DB."""
+    filters = get_active_filters()
+    log.info(f"[scheduler] Daily run — filtre: {filters}")
+
+    ensure_new_today_view()
+
+    threads = []
+    for site, fn in SCRAPERS.items():
+        t = threading.Thread(target=_run_single, args=(site, fn, filters), daemon=True)
+        t.start()
+        threads.append(t)
+
+    # Nu blocăm Flask — thread-urile rulează în background
+
+
+def create_scheduler():
+    scheduler = BackgroundScheduler(timezone="Europe/Bucharest")
+    scheduler.add_job(
+        run_all_scrapers,
+        trigger=CronTrigger(hour=7, minute=0, timezone="Europe/Bucharest"),
+        id="daily_scrape",
+        replace_existing=True,
+    )
+    return scheduler

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,209 @@
+"""
+Teste pentru:
+  - logica "nou azi" (VIEW new_today)
+  - endpoint-urile /api/apartments și /api/apartments/new
+  - endpoint /api/filters GET/POST
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+# ---- app fără scheduler activ ----
+import app as app_module
+# patch scheduler ca să nu pornească job-ul real
+with patch("scheduler.create_scheduler") as mock_sched:
+    mock_sched.return_value = MagicMock(start=MagicMock(), shutdown=MagicMock())
+
+
+@pytest.fixture
+def client():
+    from flask import Flask
+    from flask_cors import CORS
+    from routes import routes as bp
+
+    test_app = Flask(__name__)
+    CORS(test_app)
+    test_app.register_blueprint(bp)
+    test_app.config["TESTING"] = True
+    with test_app.test_client() as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Teste endpoint /api/apartments
+# ---------------------------------------------------------------------------
+
+FAKE_APARTMENTS_RESULT = {
+    "total": 2,
+    "page": 1,
+    "per_page": 20,
+    "apartments": [
+        {
+            "id": 1,
+            "source_website": "imobiliare",
+            "title": "Ap 2 camere",
+            "price": 75000,
+            "location": "Sector 2",
+            "surface": 55.0,
+            "rooms": 2,
+            "floor": "3",
+            "contact_name": "Ion",
+            "phone_number": "0720000001",
+            "link": "https://imobiliare.ro/ap1",
+            "description": "desc",
+            "scraped_at": "2026-06-12T07:30:00",
+        },
+        {
+            "id": 2,
+            "source_website": "publi24",
+            "title": "Ap 3 camere",
+            "price": 110000,
+            "location": "Sector 3",
+            "surface": 70.0,
+            "rooms": 3,
+            "floor": "1",
+            "contact_name": "Maria",
+            "phone_number": "0730000002",
+            "link": "https://publi24.ro/ap2",
+            "description": "desc2",
+            "scraped_at": "2026-06-12T08:00:00",
+        },
+    ],
+}
+
+
+def test_api_apartments_returns_list(client):
+    with patch("routes.query_apartments", return_value=FAKE_APARTMENTS_RESULT):
+        resp = client.get("/api/apartments")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "apartments" in data
+    assert "total" in data
+    assert len(data["apartments"]) == 2
+
+
+def test_api_apartments_passes_filters(client):
+    with patch("routes.query_apartments", return_value=FAKE_APARTMENTS_RESULT) as mock_q:
+        resp = client.get("/api/apartments?rooms=2&sector=2&price_min=50000&price_max=100000")
+    assert resp.status_code == 200
+    mock_q.assert_called_once_with(
+        rooms=2, sector=2, price_min=50000, price_max=100000,
+        page=1, per_page=20, sort_by="scraped_at", sort_dir="desc"
+    )
+
+
+def test_api_apartments_invalid_params(client):
+    resp = client.get("/api/apartments?rooms=abc")
+    assert resp.status_code == 400
+
+
+def test_api_apartments_pagination(client):
+    with patch("routes.query_apartments", return_value=FAKE_APARTMENTS_RESULT) as mock_q:
+        resp = client.get("/api/apartments?page=2&per_page=10")
+    assert resp.status_code == 200
+    mock_q.assert_called_once_with(
+        rooms=None, sector=None, price_min=None, price_max=None,
+        page=2, per_page=10, sort_by="scraped_at", sort_dir="desc"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Teste endpoint /api/apartments/new
+# ---------------------------------------------------------------------------
+
+FAKE_NEW_RESULT = {
+    "count": 1,
+    "apartments": [FAKE_APARTMENTS_RESULT["apartments"][0]],
+}
+
+
+def test_api_new_returns_list(client):
+    with patch("routes.query_new_today", return_value=FAKE_NEW_RESULT):
+        resp = client.get("/api/apartments/new")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "apartments" in data
+    assert "count" in data
+
+
+def test_api_new_passes_filters(client):
+    with patch("routes.query_new_today", return_value=FAKE_NEW_RESULT) as mock_q:
+        resp = client.get("/api/apartments/new?rooms=2&price_min=60000")
+    assert resp.status_code == 200
+    mock_q.assert_called_once_with(
+        rooms=2, sector=None, price_min=60000, price_max=None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Teste endpoint /api/filters
+# ---------------------------------------------------------------------------
+
+FAKE_FILTERS = {"id": 1, "rooms": 2, "sector": 0, "price_min": 10000, "price_max": 150000, "created_at": "2026-06-12T00:00:00"}
+
+
+def test_get_filters(client):
+    with patch("routes.get_active_filters", return_value=FAKE_FILTERS):
+        resp = client.get("/api/filters")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["rooms"] == 2
+
+
+def test_post_filters_valid(client):
+    with patch("routes.save_filters", return_value=5) as mock_save:
+        resp = client.post("/api/filters", json={"rooms": 3, "sector": 1, "price_min": 20000, "price_max": 100000})
+    assert resp.status_code == 201
+    assert resp.get_json()["saved"] is True
+    mock_save.assert_called_once_with(3, 1, 20000, 100000)
+
+
+def test_post_filters_invalid_price(client):
+    resp = client.post("/api/filters", json={"rooms": 2, "sector": 0, "price_min": 90000, "price_max": 10000})
+    assert resp.status_code == 400
+
+
+def test_post_filters_invalid_type(client):
+    resp = client.post("/api/filters", json={"rooms": "abc"})
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Teste logică "nou azi" — query_new_today și query_apartments (unit)
+# ---------------------------------------------------------------------------
+
+def test_query_new_today_filters_rooms():
+    """Verifică că filtrul rooms e aplicat corect."""
+    with patch("Database.database.get_connection") as mock_conn:
+        mock_cur = MagicMock()
+        mock_cur.fetchall.return_value = []
+        mock_conn.return_value.__enter__ = MagicMock(return_value=mock_conn.return_value)
+        mock_conn.return_value.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.return_value.cursor.return_value = mock_cur
+
+        from Database.database import query_new_today
+        result = query_new_today(rooms=2)
+
+    assert "apartments" in result
+    assert "count" in result
+
+
+def test_query_apartments_per_page_cap():
+    """per_page e capped la 100 în endpoint."""
+    from flask import Flask
+    from flask_cors import CORS
+    from routes import routes as bp
+
+    test_app = Flask(__name__)
+    CORS(test_app)
+    test_app.register_blueprint(bp)
+    test_app.config["TESTING"] = True
+
+    with test_app.test_client() as c:
+        with patch("routes.query_apartments", return_value={"total": 0, "page": 1, "per_page": 100, "apartments": []}) as mock_q:
+            c.get("/api/apartments?per_page=9999")
+        _, kwargs = mock_q.call_args
+        assert kwargs.get("per_page", mock_q.call_args[0][6] if mock_q.call_args[0] else 100) <= 100


### PR DESCRIPTION

- APScheduler runs all scrapers at 07:00 Europe/Bucharest using filters saved in DB
- New PostgreSQL view new_today: apartments scraped today that did not exist yesterday
- New tables: user_filters (persists filter preferences), run_log (daily run history)
- GET /api/apartments — paginated, filterable list of all apartments
- GET /api/apartments/new — apartments new since yesterday (via new_today view)
- GET/POST /api/filters — read and persist user filter preferences
- Migration migrate_v2.sql adds idx_scraped_at index
- 12 unit tests for endpoints and filter logic (all passing)